### PR TITLE
Small CSS correction

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -341,7 +341,7 @@ navbar-default .navbar-toggle .icon-bar { background-color: #fff; }
   width: auto;
 }
 
-: .col-gray-fixed {
+.col-gray-fixed {
   margin-top: 15px;
   position: fixed !important;
   width: 250px !important;


### PR DESCRIPTION
':' removed before  col-gray-fixed 
Probably the reason that blocks page column aligment looks weird